### PR TITLE
Add comment to change the CI Dockerfile

### DIFF
--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -14,6 +14,8 @@ on:
     paths:
       - ${{ env.DOCKERFILE }}
 
+  workflow_dispatch:
+
 
 jobs:
   build:

--- a/util/dockerfiles/github-ci/Dockerfile
+++ b/util/dockerfiles/github-ci/Dockerfile
@@ -1,4 +1,6 @@
 # This is a container used to run CI jobs on GH
+# An image gets built in .github/workflows/build-CI-container.yml
+# and then used in .github/workflows/CI.yml
 
 # We use 22.04 to get llvm-13
 FROM ubuntu:22.04


### PR DESCRIPTION
In #19425 I added a new GH Action to build a container. It used the
"on push to main" trigger, but while the new Workflow shows up at [1],
it did not run. My guess is that this is because the Dockerfile was a
new file and we filter the trigger based on filepath, so maybe it
doesn't register as a change.

I've also added the "on workflow_dispatch" trigger (see [2]) to
allow it to be manually run.

[1] https://github.com/chapel-lang/chapel/actions/workflows/build-CI-container.yml
[2] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>